### PR TITLE
fix: fix actions permission

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,11 @@ on:
       - main # 在 main 分支有新提交时触发
   workflow_dispatch: # 允许手动触发部署
 
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
remote: Permission to kinzzn/SaveMySelfGroup.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/kinzzn/SaveMySelfGroup.git/': The requested URL returned error: 403